### PR TITLE
Fix build on GCC 15

### DIFF
--- a/src/srvcont.c
+++ b/src/srvcont.c
@@ -520,7 +520,8 @@ lw_srvcont_wait_teams (LW_SRVCONT * cont,
     {
       log_print_str ("Unable to bind socket on port ");
       log_print_int (port);
-      log_println ("!");
+      log_print_str ("!");
+      log_println ();
 
       /*
        * We consider this a fatal error and quit the program

--- a/utils/liquidwarcol.c
+++ b/utils/liquidwarcol.c
@@ -430,7 +430,7 @@ main (int argc, char **argv)
             {
               if (FLAG_BACKUP)
                 save_backup (FILENAMES[i]);
-              convert_bitmap (FILENAMES[i]);
+              convert_bitmap ();
               save_file (FILENAMES[i]);
             }
         }


### PR DESCRIPTION
Some functions erroneously had parameters even though the parameters were actually passed via global variable.

This seems to be not allowed anymore. Removing the parameters fixes build on newer GCC.